### PR TITLE
Update PocketBase to v0.12.0

### DIFF
--- a/others/pocketbase/Dockerfile
+++ b/others/pocketbase/Dockerfile
@@ -1,6 +1,6 @@
 FROM alpine:3.17
 ARG BUILDARCH 
-ARG PB_VERSION=0.11.0
+ARG PB_VERSION=0.12.0
 RUN apk add --no-cache \
     unzip \
     ca-certificates


### PR DESCRIPTION
Release:
https://github.com/pocketbase/pocketbase/releases/tag/v0.12.0